### PR TITLE
Laravel 6.x Compatibility

### DIFF
--- a/src/LoadsNovaTranslations.php
+++ b/src/LoadsNovaTranslations.php
@@ -68,7 +68,7 @@ trait LoadsNovaTranslations
     private function loadLaravelTranslations($pckgTransDir, $pckgName)
     {
         $locale = app()->getLocale();
-        $fbLocale = app()->getFallbackLocale();
+        $fbLocale = config('app.fallback_locale');
 
         $this->loadLaravelTranslationsForLocale($locale, $pckgTransDir, $pckgName);
         $this->loadLaravelTranslationsForLocale($fbLocale, $pckgTransDir, $pckgName);


### PR DESCRIPTION
The `app()->getFallbackLocale()` method doesn't exist until Laravel 7.x. I've tweaked the line in question to be Laravel 6.x compatible.

**Note:** This targets the 2.x version of your package, which still supports L6. Unfortunately, upgrading to L7 or L8 is not currently an option for me.