### PR TITLE
chore: bump to php 8 to allow laravel 9

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@ This [Laravel Nova](https://nova.laravel.com/) package helps developers load tra
 
 ## Requirements
 
-- `php: >=7.2`
-- `laravel/framework: ^7.0 || ^8.0`
+- `php: ^7.2.0|^8.0.2`
+- `laravel/framework: ^7.0 || ^8.0 || ^9.0`
 - `laravel/nova: ^3.0`
 
 ## Installation

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
   ],
   "license": "MIT",
   "require": {
-    "php": ">=7.2.0",
+    "php": "^7.2.0|^8.0.2",
     "laravel/framework": "^7.21 || ^8.0 || ^9.0",
     "laravel/nova": "^3.0"
   },


### PR DESCRIPTION
Laravel 9 requires php ^8.0.2