### PR TITLE
Support `laravel/nova` 5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
   "license": "MIT",
   "require": {
     "php": ">=8.0",
-    "laravel/nova": "^4.0"
+    "laravel/nova": "^4.0|^5.0"
   },
   "autoload": {
     "psr-4": {


### PR DESCRIPTION
This doesn't seem to contain any breaking change so it should be fine to allow Nova 5 without any changes.